### PR TITLE
Link to page showing incoming eth transactions to this address from our contract.

### DIFF
--- a/packages/details/components/UserfeedsAddressInfo.tsx
+++ b/packages/details/components/UserfeedsAddressInfo.tsx
@@ -25,7 +25,7 @@ const renderQR = (recipientAddress, ref) => {
 export default class UserfeedsAddressInfo extends PureComponent<IUserfeedsAddressInfoProps> {
   render() {
     const { recipientAddress, linksNumber } = this.props;
-    const etherscanUrl = `https://etherscan.io/address/${recipientAddress}`;
+    const etherscanUrl = `https://etherscan.io/address/${recipientAddress}#internaltx`;
 
     return (
       <div className={style.self}>


### PR DESCRIPTION
This can be improved to go to token transfers tab for ERC20 token assets.